### PR TITLE
Removed unneeded directory change from Sass command

### DIFF
--- a/preprocessors.js
+++ b/preprocessors.js
@@ -166,7 +166,7 @@ module.exports = {
             fn: function (done) {
                 var command = 'sass -C --sourcemap=none ' + scssFile;
                 var dir = __dirname;
-                exec('cd ' + dir + '; bundle exec ' + command,
+                exec('bundle exec ' + command,
                     function (error, stdout, stderr) {
                         if ( error ) throw stderr;
                         done.resolve();


### PR DESCRIPTION
The `cd dir` was only needed before the benchmarks were moved to a separate repo.  Windows doesn't like semicolons.  
