### PR TITLE
Add Stylis

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "stylecow-plugin-prefixes": "^6.0.5",
     "stylecow-plugin-variables": "^5.1.1",
     "stylus": "^0.54.5",
-    "through2": "^2.0.3"
+    "through2": "^2.0.3",
+    "stylis": "^3.0.5"
   },
   "scripts": {
     "lint-staged": "lint-staged",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,10 @@
     "stylecow-plugin-variables": "^5.1.1",
     "stylus": "^0.54.5",
     "through2": "^2.0.3",
-    "stylis": "^3.0.5"
+    "stylis": "^3.2.0",
+    "stylis-mixin": "^0.0.1",
+    "stylis-calc": "^0.0.1",
+    "stylis-custom-properties": "^0.0.3"
   },
   "scripts": {
     "lint-staged": "lint-staged",

--- a/parsers.js
+++ b/parsers.js
@@ -29,7 +29,8 @@ var gonzales   = require('gonzales');
 var parserlib  = require('parserlib');
 var gonzalesPe = require('gonzales-pe');
 var csstree    = require('css-tree');
-var stylis     = require('stylis');
+var Stylis     = require('stylis');
+var stylis     = new Stylis();
 
 module.exports = {
     name: 'Bootstrap',

--- a/parsers.js
+++ b/parsers.js
@@ -110,7 +110,7 @@ module.exports = {
         {
             name: 'Stylis',
             fn: function () {
-                stylis('', css)
+                stylis('', css);
             }
         }
     ]

--- a/parsers.js
+++ b/parsers.js
@@ -29,6 +29,7 @@ var gonzales   = require('gonzales');
 var parserlib  = require('parserlib');
 var gonzalesPe = require('gonzales-pe');
 var csstree    = require('css-tree');
+var stylis     = require('stylis');
 
 module.exports = {
     name: 'Bootstrap',
@@ -104,6 +105,12 @@ module.exports = {
             name: 'Stylecow',
             fn: function () {
                 stylecow.parse(css).toString();
+            }
+        },
+        {
+            name: 'Stylis',
+            fn: function () {
+                stylis('', css)
             }
         }
     ]

--- a/prefixers.js
+++ b/prefixers.js
@@ -46,7 +46,7 @@ var scssFile = path.join(__dirname, 'cache/bootstrap.prefixers.scss');
 fs.writeFileSync(scssFile, scss);
 
 // Stylis
-var stylis = require('stylis')
+var stylis = require('stylis');
 
 module.exports = {
     name: 'Bootstrap',

--- a/prefixers.js
+++ b/prefixers.js
@@ -46,7 +46,8 @@ var scssFile = path.join(__dirname, 'cache/bootstrap.prefixers.scss');
 fs.writeFileSync(scssFile, scss);
 
 // Stylis
-var stylis = require('stylis');
+var Stylis = require('stylis');
+var stylis = new Stylis();
 
 module.exports = {
     name: 'Bootstrap',

--- a/prefixers.js
+++ b/prefixers.js
@@ -45,6 +45,9 @@ var scss = '@import \'compass/css3\';\n' + css
 var scssFile = path.join(__dirname, 'cache/bootstrap.prefixers.scss');
 fs.writeFileSync(scssFile, scss);
 
+// Stylis
+var stylis = require('stylis')
+
 module.exports = {
     name: 'Bootstrap',
     maxTime: 15,
@@ -89,6 +92,14 @@ module.exports = {
                     if ( err ) throw stderr;
                     done.resolve();
                 });
+            }
+        },
+        {
+            name: 'Stylis',
+            defer: true,
+            fn: function (done) {
+                stylis('', css);
+                done.resolve();
             }
         }
     ]

--- a/preprocessors.js
+++ b/preprocessors.js
@@ -184,9 +184,11 @@ module.exports = {
         },
         {
             name: 'Stylis',
-            fn: function () {
+            defer: true,
+            fn: function (done) {
                 stylis('', styi);
-            }  
+                done.resolve();
+            }
         }
     ]
 };

--- a/preprocessors.js
+++ b/preprocessors.js
@@ -103,6 +103,17 @@ for ( i = 0; i < 100; i++ ) {
     lcss += '.search { fill: black; .icon() }';
 }
 
+// Stylis
+var stylis = require('stylis');
+var styi = css;
+styi += ':root { --size: 100px; }';
+for ( i = 0; i < 100; i++ ) {
+    styi += 'body h1 a { color: black; }';
+    styi += 'h2 { width: var(--size); }';
+    styi += 'h1 { width: calc(2 * var(--size)); }';
+    styi += '.search { fill: black; width: 16px; height: 16px; }';
+}
+
 module.exports = {
     name: 'Bootstrap',
     maxTime: 15,
@@ -170,6 +181,12 @@ module.exports = {
                     done.resolve();
                 });
             }
+        },
+        {
+            name: 'Stylis',
+            fn: function () {
+                stylis('', styi);
+            }  
         }
     ]
 };

--- a/preprocessors.js
+++ b/preprocessors.js
@@ -104,7 +104,8 @@ for ( i = 0; i < 100; i++ ) {
 }
 
 // Stylis
-var stylis = require('stylis');
+var Stylis = require('stylis');
+var stylis = new Stylis();
 var styi = css;
 styi += ':root { --size: 100px; }';
 for ( i = 0; i < 100; i++ ) {
@@ -113,6 +114,12 @@ for ( i = 0; i < 100; i++ ) {
     styi += 'h1 { width: calc(2 * var(--size)); }';
     styi += '.search { fill: black; width: 16px; height: 16px; }';
 }
+
+stylis.use([
+    require('stylis-mixin'),
+    require('stylis-calc'),
+    require('stylis-custom-properties')
+]);
 
 module.exports = {
     name: 'Bootstrap',


### PR DESCRIPTION
Machine specs

```
1.3 GHz Intel Core i5
4 GB 1600 MHz DDR3
```

Parsers

```
Rework x 12.80 ops/sec ±4.42% (36 runs sampled)
PostCSS x 21.11 ops/sec ±8.46% (57 runs sampled)
PostCSS Full x 8.15 ops/sec ±7.79% (45 runs sampled)
CSSOM x 19.20 ops/sec ±6.53% (36 runs sampled)
Mensch x 17.85 ops/sec ±13.39% (37 runs sampled)
Gonzales x 5.21 ops/sec ±7.75% (18 runs sampled)
Gonzales PE x 3.99 ops/sec ±10.37% (15 runs sampled)
CSSTree x 39.73 ops/sec ±9.18% (56 runs sampled)
ParserLib x 1.79 ops/sec ±8.58% (9 runs sampled)
Stylecow x 3.97 ops/sec ±9.48% (15 runs sampled)
Stylis x 54.28 ops/sec ±4.45% (58 runs sampled)

Fastest test is Stylis at 1.37x faster than CSSTree
```

---

Preprocessors

```
libsass x 6.83 ops/sec ±2.29% (22 runs sampled)
Rework x 10.65 ops/sec ±3.86% (55 runs sampled)
PostCSS x 16.23 ops/sec ±11.21% (47 runs sampled)
Stylecow x 2.15 ops/sec ±6.36% (15 runs sampled)
Stylus x 3.67 ops/sec ±28.12% (25 runs sampled)
Less x 4.75 ops/sec ±9.14% (29 runs sampled)
Ruby Sass x 0.31 ops/sec ±8.12% (6 runs sampled)
Stylis x 26.26 ops/sec ±5.95% (49 runs sampled)

Fastest test is Stylis at 1.62x faster than PostCSS
```

---

Prefixers

```
Autoprefixer x 13.32 ops/sec ±6.51% (67 runs sampled)
Stylecow x 2.28 ops/sec ±5.97% (16 runs sampled)
nib x 1.79 ops/sec ±25.32% (15 runs sampled)
Compass x 0.15 ops/sec ±9.34% (5 runs sampled)
Stylis x 45.52 ops/sec ±14.61% (77 runs sampled)

Fastest test is Stylis at 3.4x faster than Autoprefixer
```
