### PR TITLE
Updates for Sass

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ To get results on your environment:
 
 ```sh
 npm install
-bundle install
 npm test preprocessors
 ```
 

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "postcss-value-parser": "^3.3.0",
     "pre-commit": "^1.2.2",
     "rework": "^1.0.1",
+    "sass": "^1.5.1",
     "stylecow-core": "^2.5.0",
     "stylecow-plugin-calc": "^2.0.0",
     "stylecow-plugin-nested-rules": "^5.0.1",

--- a/preprocessors.js
+++ b/preprocessors.js
@@ -127,7 +127,14 @@ module.exports = {
     maxTime: 15,
     tests: [
         {
-            name: 'libsass',
+            name: 'LibSass',
+            defer: true,
+            fn: done => {
+                libsass.render({ data: scss }, () => done.resolve());
+            }
+        },
+        {
+            name: 'LibSass sync',
             fn: () => {
                 libsass.renderSync({ data: scss });
             }

--- a/preprocessors.js
+++ b/preprocessors.js
@@ -79,6 +79,9 @@ for ( i = 0; i < 100; i++ ) {
 const scssFile = path.join(__dirname, 'cache', 'bootstrap.preprocessors.scss');
 fs.writeFileSync(scssFile, scss);
 
+// Dart Sass
+const sass = require('sass');
+
 // Stylus
 const stylus = require('stylus');
 let styl = css;
@@ -137,6 +140,19 @@ module.exports = {
             name: 'LibSass sync',
             fn: () => {
                 libsass.renderSync({ data: scss });
+            }
+        },
+        {
+            name: 'Dart Sass',
+            defer: true,
+            fn: done => {
+                sass.render({ data: scss }, () => done.resolve());
+            }
+        },
+        {
+            name: 'Dart Sass sync',
+            fn: () => {
+                sass.renderSync({ data: scss });
             }
         },
         {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3963,6 +3963,10 @@ sass-graph@^2.2.4:
     scss-tokenizer "^0.2.3"
     yargs "^7.0.0"
 
+sass@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/sass/-/sass-1.5.1.tgz#5ac0ce58eb90f67378b0f77270e40b3422788510"
+
 sax@0.5.x:
   version "0.5.8"
   resolved "https://registry.yarnpkg.com/sax/-/sax-0.5.8.tgz#d472db228eb331c2506b0e8c15524adb939d12c1"


### PR DESCRIPTION
We discussed adding Dart Sass a while back but it looks like it didn't happen.

Also adds the async versions of Sass to the benchmark. Testing both sync and async because they result in very different numbers for Dart Sass.