### PR TITLE
Make lightningcss benchmark faster

### DIFF
--- a/prefixers.js
+++ b/prefixers.js
@@ -23,6 +23,8 @@ let origin = readFileSync(example).toString()
 let cleaner = postcss([autoprefixer({ overrideBrowserslist: [] })])
 let css = cleaner.process(origin, { from: example }).css
 let processor = postcss([autoprefixer])
+let cssBuffer = Buffer.from(css);
+let targets = lightning.browserslistToTargets(browserslist('defaults'));
 
 // Stylecow
 let stylecowOut = new stylecow.Coder()
@@ -62,12 +64,11 @@ module.exports = {
         lightning
           .transform({
             filename: example,
-            code: Buffer.from(css),
-            targets: lightning.browserslistToTargets(browserslist('defaults')),
+            code: cssBuffer,
+            targets,
             minify: false,
             sourceMap: false
           })
-          .code.toString()
       }
     },
     {


### PR DESCRIPTION
Converting between strings and buffers and running browserslist accounts for a lot of the time in the Lightning CSS benchmark rather than actually transforming. I moved the `Buffer.from` and `browserslistToTargets` call out so it is only done once, and got rid of the `toString()` call on the result, and it goes from 190 ops/s to 243 ops/s on my machine. I think this is fair because the others also only run browserslist once (or not at all), and in real world usage you're likely to be able to provide a buffer rather than a string if reading/writing from a file.