### PR TITLE
add benchmarks for creating sourcemaps

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -31,7 +31,7 @@ gulp.task('bootstrap', async () => {
   })
 })
 
-for (let name of ['preprocessors', 'parsers', 'prefixers', 'tokenizers', 'linters']) {
+for (let name of ['preprocessors', 'parsers', 'prefixers', 'tokenizers', 'linters', 'sourcemaps']) {
   gulp.task(
     name,
     gulp.series('bootstrap', () => {
@@ -47,5 +47,5 @@ for (let name of ['preprocessors', 'parsers', 'prefixers', 'tokenizers', 'linter
 
 gulp.task(
   'default',
-  gulp.series('preprocessors', 'parsers', 'prefixers', 'tokenizers', 'linters')
+  gulp.series('preprocessors', 'parsers', 'prefixers', 'tokenizers', 'linters', 'sourcemaps')
 )

--- a/sourcemaps.js
+++ b/sourcemaps.js
@@ -1,0 +1,67 @@
+/* Results on Node 20.3.1, Github Actions:
+
+TODO
+*/
+
+let { existsSync, readFileSync } = require('fs')
+let { join } = require('path')
+const postcss = require('postcss')
+
+let example = join(__dirname, 'cache', 'bootstrap.css')
+let css = readFileSync(example).toString()
+
+module.exports = {
+  maxTime: 15,
+  name: 'Sourcemaps',
+  tests: [
+    {
+      defer: true,
+      fn: done => {
+        {
+          let root = postcss.parse(css, { from: example })
+          root.toResult({ map: { inline: false }, to: 'dist/bootstrap.css' }).map.toJSON()
+        }
+
+        {
+          let root = postcss.parse(css, { from: example })
+          root.toResult({ map: { absolute: true, inline: false }, to: 'dist/bootstrap.css' }).map.toJSON()
+        }
+
+        {
+          let root = postcss.parse(css, { from: example })
+          root.toResult({ map: { inline: true }, to: 'dist/bootstrap.css' })
+        }
+
+        done.resolve()
+      },
+      name: 'PostCSS'
+    }
+  ]
+}
+
+let devPath = join(__dirname, '../postcss/lib/postcss.js')
+if (existsSync(devPath)) {
+  let devPostcss = require(devPath)
+  module.exports.tests.splice(1, 0, {
+    defer: true,
+    fn: done => {
+      {
+        let root = devPostcss.parse(css, { from: example })
+        root.toResult({ map: { inline: false }, to: 'dist/bootstrap.css' }).map.toJSON()
+      }
+
+      {
+        let root = devPostcss.parse(css, { from: example })
+        root.toResult({ map: { absolute: true, inline: false }, to: 'dist/bootstrap.css' }).map.toJSON()
+      }
+
+      {
+        let root = devPostcss.parse(css, { from: example })
+        root.toResult({ map: { inline: true }, to: 'dist/bootstrap.css' })
+      }
+
+      done.resolve()
+    },
+    name: 'Next PostCSS'
+  })
+}

--- a/sourcemaps.js
+++ b/sourcemaps.js
@@ -17,20 +17,14 @@ module.exports = {
     {
       defer: true,
       fn: done => {
-        {
-          let root = postcss.parse(css, { from: example })
-          root.toResult({ map: { inline: false }, to: 'dist/bootstrap.css' }).map.toJSON()
-        }
+        let root = postcss.parse(css, { from: example })
+        root.toResult({ map: { inline: false }, to: 'dist/bootstrap.css' }).map.toJSON()
 
-        {
-          let root = postcss.parse(css, { from: example })
-          root.toResult({ map: { absolute: true, inline: false }, to: 'dist/bootstrap.css' }).map.toJSON()
-        }
+        root = postcss.parse(css, { from: example })
+        root.toResult({ map: { absolute: true, inline: false }, to: 'dist/bootstrap.css' }).map.toJSON()
 
-        {
-          let root = postcss.parse(css, { from: example })
-          root.toResult({ map: { inline: true }, to: 'dist/bootstrap.css' })
-        }
+        root = postcss.parse(css, { from: example })
+        root.toResult({ map: { inline: true }, to: 'dist/bootstrap.css' })
 
         done.resolve()
       },
@@ -45,20 +39,14 @@ if (existsSync(devPath)) {
   module.exports.tests.splice(1, 0, {
     defer: true,
     fn: done => {
-      {
-        let root = devPostcss.parse(css, { from: example })
-        root.toResult({ map: { inline: false }, to: 'dist/bootstrap.css' }).map.toJSON()
-      }
+      let root = devPostcss.parse(css, { from: example })
+      root.toResult({ map: { inline: false }, to: 'dist/bootstrap.css' }).map.toJSON()
 
-      {
-        let root = devPostcss.parse(css, { from: example })
-        root.toResult({ map: { absolute: true, inline: false }, to: 'dist/bootstrap.css' }).map.toJSON()
-      }
+      root = devPostcss.parse(css, { from: example })
+      root.toResult({ map: { absolute: true, inline: false }, to: 'dist/bootstrap.css' }).map.toJSON()
 
-      {
-        let root = devPostcss.parse(css, { from: example })
-        root.toResult({ map: { inline: true }, to: 'dist/bootstrap.css' })
-      }
+      root = devPostcss.parse(css, { from: example })
+      root.toResult({ map: { inline: true }, to: 'dist/bootstrap.css' })
 
       done.resolve()
     },

--- a/sourcemaps.js
+++ b/sourcemaps.js
@@ -1,6 +1,6 @@
 /* Results on Node 20.3.1, Github Actions:
 
-TODO
+PostCSS: 389 ms
 */
 
 let { existsSync, readFileSync } = require('fs')


### PR DESCRIPTION
Sourcemap generation is not currently benchmarked but this is the slowest part of PostCSS.
Because it is a blindspot it is also harder to improve and to prevent regressions.